### PR TITLE
added new "JSValuer" for more direct way to override

### DIFF
--- a/value.go
+++ b/value.go
@@ -17,8 +17,17 @@ const valueFieldName = "Value"
 
 var jsValueType = reflect.TypeOf(js.Value{})
 
+type JSValuer interface {
+	JSValue() js.Value
+}
+
 // Value Returns the js value of a type
 func Value(p interface{}) js.Value {
+	vr, ok := p.(JSValuer)
+	if ok {
+		return vr.JSValue()
+	}
+
 	t := reflect.TypeOf(p)
 	rv := reflect.ValueOf(p)
 

--- a/value.go
+++ b/value.go
@@ -56,6 +56,9 @@ func structValue(v js.Value, p interface{}) {
 	for i := 0; i < t.NumField(); i++ {
 		field := t.Field(i)
 		fv := rv.Field(i)
+		if !fv.CanInterface() {
+			continue
+		}
 
 		fn := field.Name
 


### PR DESCRIPTION
Finding this useful. Probably will deprecate automated embedded `js.Value` detection in favour. Thoughts? 

Essentially allows for lazy loading the js value, and ensuring it's always initialized when it's accessed. 

```go
type JSValuer interface {
	JSValue() js.Value
}
```